### PR TITLE
Require Once TypeDefinitions.inc

### DIFF
--- a/library/Vmwarephp/WsdlClassMapper.php
+++ b/library/Vmwarephp/WsdlClassMapper.php
@@ -7,6 +7,7 @@ class WsdlClassMapper {
 
 	function __construct($classDefinitionsFilePath = null) {
 		$this->classDefinitionsFilePath = $classDefinitionsFilePath ? : dirname(__FILE__) . '/TypeDefinitions.inc';
+		require_once $this->classDefinitionsFilePath;
 	}
 
 	function getClassMap() {
@@ -63,7 +64,9 @@ class WsdlClassMapper {
 
 	private function cacheClassMap($classMap) {
 		if (!$this->useClassMapCaching) return;
-		file_put_contents($this->makeCacheFilePath(), serialize($classMap));
+		if (!file_put_contents($this->makeCacheFilePath(), serialize($classMap))) {
+			throw new Exception('\\Vmwarephp\\WsdlClassMapper is configured to cache the class map but was not able to. Check the permissions on the cache directory.');
+		}
 	}
 
 	private function makeCacheFilePath() {


### PR DESCRIPTION
...appropriate place to do this but I'm open to a better solution. Kinda feel like I was missing something since practically no SOAP requests will work without this. Also throw an exception if the class map is supposed to be cached but fails. If you're expecting this to be cached but directory permissions prevent it you are going to be wasting a lot of processing time generating it over and over again so it's good to get that feedback instead of debugging why your script is timing out. Maybe a warning would be more appropriate.
