### PR TITLE
SoapClient: add stream_context options to ignore self-signed SSL

### DIFF
--- a/library/Vmwarephp/Factory/SoapClient.php
+++ b/library/Vmwarephp/Factory/SoapClient.php
@@ -11,15 +11,23 @@ class SoapClient {
 		$this->wsdlFilePath = $wsdlFilePath ? : $this->getWsdlFilePath();
 	}
 
-	function make(\Vmwarephp\Vhost $vhost, $useExceptions = 1, $trace = 1) {
-		$options = array(
-			'trace' => $trace,
-			'location' => $this->makeRequestsLocation($vhost),
-			'exceptions' => $useExceptions,
-			'connection_timeout' => 10,
-			'classmap' => $this->wsdlClassMapper->getClassMap(),
-			'features' => SOAP_SINGLE_ELEMENT_ARRAYS + SOAP_USE_XSI_ARRAY_TYPE
-		);
+  function make(\Vmwarephp\Vhost $vhost, $useExceptions = 1, $trace = 1) {
+    $options = array(
+      'trace'              => $trace,
+      'location'           => $this->makeRequestsLocation($vhost),
+      'exceptions'         => $useExceptions,
+      'connection_timeout' => 10,
+      'classmap'           => $this->wsdlClassMapper->getClassMap(),
+      'features'           => SOAP_SINGLE_ELEMENT_ARRAYS + SOAP_USE_XSI_ARRAY_TYPE,
+      'stream_context'     => stream_context_create(
+        array(
+          'ssl' => array(
+            'verify_peer'      => false,
+            'verify_peer_name' => false,
+          )
+        )
+      )
+    );
 		$soapClient = $this->makeDefaultSoapClient($this->wsdlFilePath, $options);
 		if (!$soapClient) throw new Ex\CannotCreateSoapClient();
 		return $soapClient;


### PR DESCRIPTION
Since PHP 5.6, the SoapClient validates the SSL/HTTPs endpoint. By default, it won't allow a self-signed SSL certificate and will quietly fail with the following error:

```
  [Vmwarephp\Exception\Soap]
  HTTP: Could not connect to host.
```

In order to emulate PHP 5.4/5.5 behaviour, I've added the stream_context options that will still validate self signed certificates.

While it isn't exactly safe, it _is_ consistent behaviour now across PHP 5.4, 5.5 and 5.6.

The fix is also described in the following PHP bugreport: https://bugs.php.net/bug.php?id=68855
