### PR TITLE
Added search for InstanceUuid

### DIFF
--- a/library/Vmwarephp/Service.php
+++ b/library/Vmwarephp/Service.php
@@ -42,6 +42,15 @@ class Service {
 		});
 		return empty($objects) ? null : end($objects);
 	}
+	
+	function findManagedObjectByInstanceUuid($objectType, $uuid, $propertiesToCollect = array()) {
+		$propertiesToCollect = array_merge($propertiesToCollect, ['config']);
+		$allObjects = $this->findAllManagedObjects($objectType, $propertiesToCollect);
+		$objects = array_filter($allObjects, function ($object) use ($uuid) {
+			return $object->config->instanceUuid == $uuid;
+		});
+		return empty($objects) ? null : end($objects);
+	}
 
 	function connect() {
 		if ($this->session) {


### PR DESCRIPTION
In a situation where you have multiple hosts with the same name, you can only find one with the current code. The global unique identifier for the hosts is the instanceUuid within the VirtualMachineConfigInfo object. You can use this one to find the specific host.